### PR TITLE
[Hotfix] - Remove Inverse A Move

### DIFF
--- a/msg/SetWalking.msg
+++ b/msg/SetWalking.msg
@@ -3,4 +3,3 @@ float64 x_move 0.0
 float64 y_move 0.0
 float64 a_move 0.0
 bool aim_on false
-bool inverse_a_move false


### PR DESCRIPTION
## Jira Link: 

## Description

```inverse_a_move``` serves the same functionality as ```aim_on```, therefore it is redundant.

## Type of Change

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [ ] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.